### PR TITLE
Fix to probe cargo after the hotfix.

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -506,7 +506,7 @@ AGO.Ogame = {
         ) * AGO.Uni.globalDeuteriumSaveFactor) : 0
     }, getShipCapacity: function (a) {
         let capacity = "210" === a && AGO.Uni.probeCargo ? AGO.Uni.probeCargo : AGO.Item[a].capacity;
-        return Math.round(capacity * (1 + (AGO.Units.get("114") || 0) * (AGO.Uni.cargoHyperspaceTechMultiplier / 100)) * 10) / 10;
+        return Math.round(capacity * (1 + (AGO.Units.get("114") || 0) * (AGO.Uni.cargoHyperspaceTechMultiplier / 100)));
     }, getShipSpeed: function (a) {
         AGO.Ogame.initShipSpeed && (AGO.Ogame.initShipSpeed(), AGO.Ogame.initShipSpeed = null);
         return AGO.Item[a].speed

--- a/js/messages.js
+++ b/js/messages.js
@@ -611,11 +611,12 @@ AGO.Messages = {
             let ship = "0";
             let shipsToSend = 0;
             let speedSetting = AGO.Option.get("FA4", 10);
+            let percentCargos = 1 + AGO.Option.get('FA3') / 100;
             switch (shipSetting) {
                 default:
                 case 0: ship = "203"; shipsToSend = p.lc; break;
                 case 1: ship = "202"; shipsToSend = p.sc; break;
-                case 2: ship = "210"; shipsToSend = p.sc * 1000; break;
+                case 2: ship = "210"; shipsToSend = Math.ceil(p.loot / AGO.Ogame.getShipCapacity("210") * percentCargos); break;
             }
             aAttack.href = '/game/index.php?page=fleet1&galaxy=' + p.galaxy + '&system=' + p.system + '&position=' + p.position + '&type=' + (p.isMoon === '1' ? '3' : '1') + '&routine=3&am' + ship + "=" + shipsToSend + (shipSetting === 2 ? "&speed=" + speedSetting : "");
             aAttack.textContent = 'A';

--- a/js/messages.js
+++ b/js/messages.js
@@ -365,6 +365,7 @@ AGO.Messages = {
                 p.loot = NMR.parseIntRess(DOM.getAttribute('.tooltipRight', message, 'title', ''));
                 var a, b = AGO.Option.get('FA3') / 100;
                 (a = STR.getMatches(DOM.getAttribute('.tooltipRight', message, 'title', ''), /(?:[=])([0-9]+)(?:["])/g)) ? (p.sc = NMR.parseInt(a[0] * (1 + b)), p.lc = NMR.parseInt(a[1] * (1 + b))) : 0;
+                p.probes = Math.ceil(p.loot / AGO.Ogame.getShipCapacity("210") * (1 + b));
                 p.metal = NMR.parseIntRess(DOM.queryAll('.resspan', message)[0].textContent);
                 p.crystal = NMR.parseIntRess(DOM.queryAll('.resspan', message)[1].textContent);
                 p.deut = NMR.parseIntRess(DOM.queryAll('.resspan', message)[2].textContent);
@@ -611,12 +612,11 @@ AGO.Messages = {
             let ship = "0";
             let shipsToSend = 0;
             let speedSetting = AGO.Option.get("FA4", 10);
-            let percentCargos = 1 + AGO.Option.get('FA3') / 100;
             switch (shipSetting) {
                 default:
                 case 0: ship = "203"; shipsToSend = p.lc; break;
                 case 1: ship = "202"; shipsToSend = p.sc; break;
-                case 2: ship = "210"; shipsToSend = Math.ceil(p.loot / AGO.Ogame.getShipCapacity("210") * percentCargos); break;
+                case 2: ship = "210"; shipsToSend = p.probes; break;
             }
             aAttack.href = '/game/index.php?page=fleet1&galaxy=' + p.galaxy + '&system=' + p.system + '&position=' + p.position + '&type=' + (p.isMoon === '1' ? '3' : '1') + '&routine=3&am' + ship + "=" + shipsToSend + (shipSetting === 2 ? "&speed=" + speedSetting : "");
             aAttack.textContent = 'A';


### PR DESCRIPTION
Ogame version 6.8.5-pl1 changed how probe cargo is displayed and works. Removed the rounding to with one trailing decimal, set new calculation for probes to send on attack button as the cargo between SCs and probes is no longer hard-locked 1000:1.