### PR TITLE
When replacing times with local time, store the original server time

### DIFF
--- a/js/fleet3.js
+++ b/js/fleet3.js
@@ -93,7 +93,7 @@ AGO.Fleet3 = {
                     DOM.setStyleDisplay(f.parentNode), h = DOM.getTextChild(f.parentNode), DOM.appendSPAN(d, "ago_fleet_label", h), DOM.appendSPAN(d, "ago_fleet_duration");
                 }
                 if (f = b.querySelector("#arrivalTime")) {
-                    f.textContent = AGO.Time.convertLocal(f.textContent, "[H]:[i]:[s]"), DOM.setStyleDisplay(f.parentNode.parentNode), DOM.appendSPAN(d, "ago_fleet_name", DOM.getTextChild(f.parentNode.parentNode)), g = DOM.appendSPAN(d, "ago_fleet_arrival"), g.appendChild(f);
+                    f.setAttribute('data-ago-server-time', f.textContent), f.textContent = AGO.Time.convertLocal(f.textContent, "[H]:[i]:[s]"), DOM.setStyleDisplay(f.parentNode.parentNode), DOM.appendSPAN(d, "ago_fleet_name", DOM.getTextChild(f.parentNode.parentNode)), g = DOM.appendSPAN(d, "ago_fleet_arrival"), g.appendChild(f);
                 }
                 d = DOM.appendDIV(c, {
                         "class": "ago_fleet_details",

--- a/js/main.js
+++ b/js/main.js
@@ -1567,7 +1567,7 @@ AGO.Events = {
                         " ago_panel_add", b.fleetType = HTML.hasClass(c, "neutral") ? 2 : HTML.hasClass(c, "hostile") ? 1 : b.reverse ? 4 : 3;
                 } else if (HTML.hasClass(c, "arrivalTime")) {
                     c = (a.textContent || ""
-                    ).split(" ")[0], a.textContent = AGO.Time.convertLocal(c, "[H]:[i]:[s]");
+                    ).split(" ")[0], a.setAttribute('data-ago-server-time', c), a.textContent = AGO.Time.convertLocal(c, "[H]:[i]:[s]");
                 } else if (HTML.hasClass(c, "missionFleet")) {
                     b.missionName = 2 <= b.unionType ? "" : b.unionType ? AGO.Label.get("LM02") : DOM.getAttribute("img", a, "title", 7).split("|")[1];
                 } else if (HTML.hasClass(c, "originFleet")) {

--- a/js/messages.js
+++ b/js/messages.js
@@ -206,6 +206,7 @@ AGO.Messages = {
                 var spanTime = DOM.query('.msg_head .msg_date', AGO.Messages.visibleMessages[msgId]);
                 var msgTime = DOM.getText(spanTime);
                 spanTime.textContent = AGO.Time.convertLocal(msgTime);
+                spanTime.setAttribute('data-ago-server-time', msgTime);
             }
         });
     },

--- a/js/movement.js
+++ b/js/movement.js
@@ -43,11 +43,11 @@ AGO.Movement = {
                     }
                     if (c = a[e].querySelector(".absTime")) {
                         f = (c.textContent || ""
-                        ).split(" ")[0], c.textContent = AGO.Time.convertLocal(f, "[H]:[i]:[s]");
+                        ).split(" ")[0], c.setAttribute('data-ago-server-time', f), c.textContent = AGO.Time.convertLocal(f, "[H]:[i]:[s]");
                     }
                     if (c = a[e].querySelector(".nextabsTime")) {
                         f = (c.textContent || ""
-                        ).split(" ")[0], c.textContent = AGO.Time.convertLocal(f, "[H]:[i]:[s]");
+                        ).split(" ")[0], c.setAttribute('data-ago-server-time', f), c.textContent = AGO.Time.convertLocal(f, "[H]:[i]:[s]");
                     }
                     2 === g && a[e].querySelector("span.fedAttack") && DOM.setAttribute(".reversal .icon_link img", a[e], "src", HTML.urlImage("icon_return_red.png"))
                 }

--- a/js/overlays.js
+++ b/js/overlays.js
@@ -334,7 +334,7 @@ AGO.Phalanx = {
             } else if (HTML.hasClass(c, "arrivalTime")) {
                 c = (d.textContent ||
                     ""
-                ).split(" ")[0], d.textContent = AGO.Time.convertLocal(c, "[H]:[i]:[s]");
+                ).split(" ")[0], d.setAttribute('data-ago-server-time', c), d.textContent = AGO.Time.convertLocal(c, "[H]:[i]:[s]");
             } else if (HTML.hasClass(c, "descFleet")) {
                 b.descFleet = (d.textContent || ""
                 ).trim(), 2 <= b.unionType && (d.textContent = ""


### PR DESCRIPTION
This allows other plugins that are aware of AGR to utilize the server time instead of the users local time. This is particularly important when data is exported to an external server like galaxytool, and needs to be consistent across players.