### PR TITLE
CSS fix empire view

### DIFF
--- a/skin/ago/pages_empire.css
+++ b/skin/ago/pages_empire.css
@@ -1,63 +1,63 @@
-.ago_improve .overview_equipment .anythingSlider {
+.ago_improve #empireComponent .overview_equipment .anythingSlider {
     padding: 0;
 }
 
-.ago_improve .items.groupitems + div {
+.ago_improve #empireComponent .items.groupitems + div {
     color: #a19491;
     line-height: 28px;
     text-align: center
 }
 
-.ago_improve #wrapTL {
+.ago_improve #empireComponent #wrapTL {
     height: 192px
 }
 
-.ago_improve .planetImg {
+.ago_improve #empireComponent .planetImg {
     width: 100px
 }
 
-.ago_improve .planetImg img {
+.ago_improve #empireComponent .planetImg img {
     width: 100px;
     height: 100px
 }
 
-.ago_improve #tab-left {
+.ago_improve #empireComponent #tab-left {
     height: 104px;
     margin: -13px -4px 0 0
 }
 
-.ago_improve .planetHead {
+.ago_improve #empireComponent .planetHead {
     width: 102px
 }
 
-.ago_improve .planetData {
+.ago_improve #empireComponent .planetData {
     text-align: center
 }
 
-.ago_improve .planetData div {
+.ago_improve #empireComponent .planetData div {
     padding: 0
 }
 
-.ago_improve .planetname, .ago_improve .planet {
+.ago_improve #empireComponent .planetname, .ago_improve #empireComponent .planet {
     width: 106px
 }
 
-.ago_improve .planetData ul {
+.ago_improve #empireComponent .planetData ul {
     width: 102px;
     text-align: center
 }
 
-.ago_improve .planetData li {
+.ago_improve #empireComponent .planetData li {
     width: 91px;
     font: 100 9px Verdana, Arial, SunSans-Regular, Sans-Serif;
     float: none;
     text-align: center
 }
 
-.ago_improve div.row {
+.ago_improve #empireComponent div.row {
     width: 106px
 }
 
-.ago_improve div.values {
+.ago_improve #empireComponent div.values {
     width: 102px
 }


### PR DESCRIPTION
They added the id of the empirecomponent to most of the selectors, therefor the default ogame styles got precedence over the improvements.